### PR TITLE
Pin Undertow version to maintain Java 8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ implementation group: 'com.mabl', name: 'pac-interpreter', version: '1.+'
 </dependency>
 ```
 
+### Java
+
+This library is compatible with Java 8 or newer.
+
 ## Quickstart
 
 Please see the full documentation below this example for more information.

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     // Test deps:
     testImplementation group: 'junit', name: 'junit', version: '4.+'
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.+'
-    testImplementation group: 'io.undertow', name: 'undertow-core', version: '2.2.+'
+    testImplementation group: 'io.undertow', name: 'undertow-core', version: '2.2.26.Final'
 }
 
 java {

--- a/src/test/java/com/mabl/net/proxy/PacInterpreterTest.java
+++ b/src/test/java/com/mabl/net/proxy/PacInterpreterTest.java
@@ -28,7 +28,7 @@ abstract public class PacInterpreterTest {
 
     @Before
     public void silenceGraalvmWarnings() {
-        System.setProperty("polyglot.engine.WarnInterpreterOnly", Boolean.TRUE.toString());
+        System.setProperty("polyglot.engine.WarnInterpreterOnly", Boolean.FALSE.toString());
     }
 
     @After


### PR DESCRIPTION
The `+` dependency picked up a newer version of Undertow that is not compatible with Java 8.