### PR TITLE
Support tagging to automatically release version to Maven Central

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,46 @@
+name: Build and publish artifacts
+on:
+  push:
+    tags:
+      # Run on all tags (but not branches); releases artifact to Maven Central
+      # Note this is NOT REGEX - see https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+      - v[0-9]+.[0-9]+.[0-9]+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-22.04 # LTS EoL Apr 2025
+
+    env:
+      ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_PUBLISH_USERNAME }}
+      ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PUBLISH_PASSWORD }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '8.x'
+          java-package: jdk
+          architecture: x64
+          distribution: temurin
+
+      - uses: actions/cache@v3
+        with:
+          path: ~/.gradle
+          key: ${{ runner.OS }}-gradle-${{ hashFiles('**/build.gradle') }}
+          restore-keys: |
+            ${{ runner.OS }}-gradle-
+            ${{ runner.OS }}
+
+      - name: Install Dependencies
+        run: |
+          ./gradlew dependencies
+
+      - name: Show Versions
+        run: |
+          echo "java: $(java -version)"
+
+      - name: Extract branch name
+        shell: bash
+        run: echo "BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
+
+      - name: Close/release Nexus staging repository
+        run: ./gradlew closeAndReleaseRepository -PisTag="true"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,17 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0"
+    }
+}
+
 plugins {
     id 'java-library'
     id 'maven-publish'
     id 'signing'
+    id 'io.codearte.nexus-staging' version '0.30.0'
     id 'eclipse'
     id 'idea'
 }
@@ -11,15 +21,20 @@ repositories {
 }
 
 ext {
-    baseVersion = '1.0.0'
+    baseVersion = '1.0.1'
 
     getBranch = {
         return project.findProperty('branch') ?: ''
     }
 
-    determineProjectVersion = { baseVersion, branch ->
+    getIsTag = {
+        return project.findProperty('isTag') ?: ''
+    }
+
+    determineProjectVersion = { baseVersion, branch, isTag ->
         projectVersion = baseVersion
-        if (!branch.equals("main")) {
+        // If we're not on main and we're not tagging, we need to append '-SNAPSHOT' and (optionally) the branch name to the version:
+        if (!branch.equals("main") && !isTag.equals("true")) {
             if (!branch.isEmpty()) {
                 projectVersion = "${projectVersion}-${branch}"
             }
@@ -31,7 +46,7 @@ ext {
 
 group = 'com.mabl'
 archivesBaseName = 'pac-interpreter'
-version = determineProjectVersion(baseVersion, getBranch())
+version = determineProjectVersion(baseVersion, getBranch(), getIsTag())
 
 java {
     toolchain {
@@ -70,6 +85,7 @@ ext {
     releasesUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
     snapshotsUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
 }
+
 publishing {
     repositories {
         maven {
@@ -115,4 +131,10 @@ signing {
     def signingPassword = findProperty("signingPassword")
     useInMemoryPgpKeys(signingKey, signingPassword)
     sign publishing.publications.mavenJava
+}
+
+nexusStaging {
+    serverUrl = "https://s01.oss.sonatype.org/service/local/"
+    username = System.getenv('ORG_GRADLE_PROJECT_sonatypeUsername') ?: ''
+    password = System.getenv('ORG_GRADLE_PROJECT_sonatypePassword') ?: ''
 }

--- a/tag.sh
+++ b/tag.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+BRANCH=$(git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/')
+if [ "$BRANCH" != "main" ]; then
+	echo "Must be on main branch to tag"
+	exit 1
+fi
+
+# Extract the version from build.gradle, and use it as the tag:
+VERSION_RE="^.*baseVersion = '([0-9]+\.[0-9]+\.[0-9]+)'.*"
+VERSION_STRING="$(grep 'baseVersion =' build.gradle)"
+if [[ ${VERSION_STRING} =~ ${VERSION_RE} ]]; then
+  VERSION=${BASH_REMATCH[1]}
+fi
+
+if [ -z "${VERSION}" ]; then
+  echo "Invalid version found in [${VERSION_STRING}]"
+  exit 1
+fi
+
+TAG="v${VERSION}"
+HASH=$(git rev-parse HEAD)
+git tag -a -m "${HASH}" "${TAG}"
+git push origin "${TAG}"


### PR DESCRIPTION
I released version `1.0.0` manually via the Sonatype Nexus UI.  This process involves finding the "staging" repository that is created when publishing artifacts via branch/main builds and "closing" it, which results in the artifact being deployed to Maven Central.  They couldn't have made that process more confusing if they tried, and I pity the next person who has to do this.

The goal of this PR is to automatically complete the process of closing/releasing the staging repository when this repo is tagged using the `tag.sh` script.
